### PR TITLE
fix(footer): correct link attribute in footer partial

### DIFF
--- a/layouts/partials/foot.html
+++ b/layouts/partials/foot.html
@@ -7,7 +7,7 @@
 			{{- if .icon -}}
 			<img src="/icons/{{- .icon -}}" alt="{{- .name -}}" />&nbsp;
 			{{- end -}}
-			<a href="{{- .link -}}">{{- .name -}}</a>
+			<a href="{{- .url -}}">{{- .name -}}</a>
 		</li>
 		{{- end -}}
 	</ul>


### PR DESCRIPTION
Changed the link field to use `.url` instead of `.link` in the footer template. This aligns with the data structure where URLs are stored under the `url` key, ensuring that the links function as intended. This change corrects navigation issues due to incorrect key usage.